### PR TITLE
Missing make install

### DIFF
--- a/tasks/install.src.yml
+++ b/tasks/install.src.yml
@@ -11,4 +11,4 @@
 
 - name: Build nodejs
   shell: >
-    cd {{nodejs_home}}/src/node-v{{nodejs_version}} && ./configure && make -j `nproc`
+    cd {{nodejs_home}}/src/node-v{{nodejs_version}} && ./configure && make -j `nproc` && make install


### PR DESCRIPTION
When selecting the option `nodejs_install: src` wasn't installing because the last step `make install` was missing.